### PR TITLE
add a simple sliding window reorder buffer for streaming live points

### DIFF
--- a/lib/twitter-backend.js
+++ b/lib/twitter-backend.js
@@ -1,13 +1,9 @@
 var Juttle = require('juttle/lib/runtime').Juttle;
 var JuttleMoment = require('juttle/lib/moment/juttle-moment');
 var Twitter = require('twitter');
+var Heap = require('heap');
 
 var client;
-
-var moment = require('juttle/node_modules/moment');
-moment.createFromInputFallback = function(config) {
-  config._d = new Date(config._i);
-};
 
 var Read = Juttle.proc.base.extend({
     sourceType: 'batch',
@@ -26,8 +22,15 @@ var Read = Juttle.proc.base.extend({
         this.total = options.total || 1000;
         this.count = options.count || 100;
 
+        this.delay = options.delay || JuttleMoment.duration(1, 's');
+
         // buffer of received tweets for search mode
         this.buffer = [];
+
+        // live buffer for tweets in streaming mode
+        this.live = new Heap(function(p1, p2) {
+            return p1.time.lt(p2.time) ? -1 : 1;
+        });
     },
 
     start: function() {
@@ -41,11 +44,24 @@ var Read = Juttle.proc.base.extend({
     start_streaming: function() {
         var self = this;
 
+        this.live_window_start = new JuttleMoment().add(this.delay);
+        this.live_window_next = this.live_window_start.add(this.delay);
+
+        this.program.scheduler.schedule(this.live_window_next.unixms(), function() { self.stream_points() });
+
         client.stream('statuses/filter', {track: this.query}, function(stream) {
             self.stream = stream;
 
             stream.on('data', function(tweet) {
-                self.emit_tweets([tweet]);
+                var pt = self.toJuttle(tweet);
+                if (pt) {
+                    if (pt.time.gt(self.live_window_start)) {
+                        self.logger.warn('point arrived late', pt.time.toJSON(), self.live_window_start.toJSON());
+                        return;
+                    }
+                    self.live.push(pt);
+                    self.logger.debug('buffered', self.live.size(), 'pts')
+                }
             });
 
             stream.on('error', function(error) {
@@ -53,6 +69,25 @@ var Read = Juttle.proc.base.extend({
                 self.logger.error(error)
             });
         });
+    },
+
+    stream_points: function() {
+        var self = this;
+
+        this.logger.debug('in stream', this.live_window_next.toJSON());
+
+        var tosend = [];
+        this.live_window_start = this.live_window_start.add(this.delay);
+        while (this.live.size() && (this.live.peek().time < this.live_window_start)) {
+            tosend.push(this.live.pop());
+        }
+        if (tosend.length !== 0) {
+            this.logger.debug('emitting', tosend.length, 'points', JSON.stringify(tosend, null, 4));
+            this.emit(tosend);
+        }
+
+        this.live_window_next = this.live_window_next.add(this.delay);
+        this.program.scheduler.schedule(this.live_window_next.unixms(), function() { self.stream_points(); });
     },
 
     search: function() {
@@ -115,21 +150,27 @@ var Read = Juttle.proc.base.extend({
         }
     },
 
+    toJuttle: function(tweet) {
+        if (tweet.created_at === undefined) {
+            return null;
+        }
+
+        return {
+            time: new JuttleMoment({rawDate: new Date(tweet.created_at)}),
+            user: '@' + tweet.user.screen_name,
+            text: tweet.text
+        };
+    },
+
     // Emit the array of tweets in reverse order since that's how they come in.
     emit_tweets: function(tweets) {
         var pts = [];
 
         for (var i = tweets.length - 1; i >= 0; --i) {
-            var tweet = tweets[i];
-            if (tweet.created_at === undefined) {
-                return;
+            var pt = this.toJuttle(tweets[i]);
+            if (pt) {
+                pts.push(pt);
             }
-            var pt = {
-                time: new JuttleMoment(tweet.created_at),
-                user: '@' + tweet.user.screen_name,
-                text: tweet.text
-            };
-            pts.push(pt);
         }
 
         this.emit(pts);

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "author": "Michael Demmer <demmer@jut.io>",
   "license": "Apache-2.0",
   "dependencies": {
+    "heap": "^0.2.6",
     "moment": "^2.10.6",
     "twitter": "^1.2.5"
   }


### PR DESCRIPTION
The live stream of points may come in out of order which causes
problems with downstream reducers. So add a simple sliding window with
a configurable delay during which it will buffer the points and
reorder them before emitting.

There is currently no throttling for overflow.
