### PR TITLE
Cleanup package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "author": "Michael Demmer <demmer@jut.io>",
   "dependencies": {
     "heap": "^0.2.6",
     "moment": "^2.10.6",


### PR DESCRIPTION
This is part of an effort to make sure all our `package.json` are ready for publishing and contain the same metadata.
