### PR TITLE
Drop sourceType property from read

### DIFF
--- a/lib/twitter-adapter.js
+++ b/lib/twitter-adapter.js
@@ -6,7 +6,6 @@ var Heap = require('heap');
 var client;
 
 var Read = Juttle.proc.source.extend({
-    sourceType: 'batch',
     procName: 'readx-twitter',
 
     initialize: function(options, params, pname, location, program, juttle) {


### PR DESCRIPTION
As read now inherits from Juttle source proc and program checks for
that, the sourceType property is not needed.

refs: https://github.com/juttle/juttle/pull/110