### PR TITLE
package.json: relax the juttle dependency to >=0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "twitter": "^1.2.5"
   },
   "peerDependencies": {
-    "juttle": "^0.2.0"
+    "juttle": ">=0.2.0"
   },
   "engines": {
     "node": ">=4.2.0",


### PR DESCRIPTION
As discussed in https://github.com/juttle/juttle/issues/145, change the juttle
peer dependency to a looser expression of >= 0.2.0 as opposed to the stricter
dependency of ^0.2.0.