### PR TITLE
fix historical mode misuse of promisifyAll

### DIFF
--- a/lib/twitter-adapter.js
+++ b/lib/twitter-adapter.js
@@ -172,7 +172,7 @@ class Read extends AdapterRead {
                           'max_id=' + opts.max_id, 'count=' + opts.count);
 
         return this.client.getAsync('search/tweets', opts)
-        .spread((tweets, response) => {
+        .then((tweets) => {
             let statuses = tweets.statuses;
             this.logger.debug('search returned', statuses.length, 'tweets');
 


### PR DESCRIPTION
The semnantics in bluebird promises changed in 3.x such that the
default behavior only returns a single result. This means that the
code written to use .spread was failing with an error during the
historical reads and needs to be changed to use .then.